### PR TITLE
Additional iam policies

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -57,6 +57,13 @@ resource "aws_iam_role_policy_attachment" "ssm_attach" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "aws_iam_role_policy_attachment" "additional_policy_attachments" {
+  for_each = toset(var.additional_policy_arns)
+
+  role       = aws_iam_role.star_rocks_role.name
+  policy_arn = each.value
+}
+
 resource "aws_iam_instance_profile" "star_rocks_instance_profile" {
   name = "${var.project}-${var.environment}-ip"
   role = aws_iam_role.star_rocks_role.name

--- a/iam.tf
+++ b/iam.tf
@@ -58,10 +58,10 @@ resource "aws_iam_role_policy_attachment" "ssm_attach" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional_policy_attachments" {
-  for_each = var.additional_policy_arns
+  count = length(var.additional_policy_arns)
 
   role       = aws_iam_role.star_rocks_role.name
-  policy_arn = each.value
+  policy_arn = var.additional_policy_arns[count.index]
 }
 
 resource "aws_iam_instance_profile" "star_rocks_instance_profile" {

--- a/iam.tf
+++ b/iam.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy_attachment" "ssm_attach" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional_policy_attachments" {
-  for_each = toset(var.additional_policy_arns)
+  for_each = var.additional_policy_arns
 
   role       = aws_iam_role.star_rocks_role.name
   policy_arn = each.value

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_instance" "star_rocks_compute_nodes" {
 
 resource "aws_instance" "star_rocks_frontend" {
   count = var.frontend_instance_count
-  ami                    = data.aws_ami.al2023.id
+  ami                    = var.ami_id
   instance_type          = var.monitoring_instance_type
   user_data = templatefile("${path.module}/templates/frontend_startup.sh.tpl", {
     starrocks_version        = var.star_rocks_version
@@ -91,7 +91,7 @@ resource "aws_instance" "star_rocks_frontend" {
 }
 
 resource "aws_instance" "star_rocks_grafana" {
-  ami                    = data.aws_ami.al2023.id
+  ami                    = var.ami_id
   instance_type          = var.monitoring_instance_type
   user_data = templatefile("${path.module}/templates/grafana_startup.sh.tpl", {
     prometheus_ip = aws_instance.star_rocks_prometheus.private_ip
@@ -129,7 +129,7 @@ resource "aws_instance" "star_rocks_grafana" {
 
 
 resource "aws_instance" "star_rocks_prometheus" {
-  ami                    = data.aws_ami.al2023.id
+  ami                    = var.ami_id
   instance_type          = var.monitoring_instance_type
   user_data              = templatefile("${path.module}/templates/prometheus_startup.sh.tpl", {
     cn_tag = "${var.project}-cn"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_ami" "al2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023.6.*.0-kernel-6.1-x86_64"]
+    values = ["al2023-ami-*-x86_64"]
   }
 
   filter {

--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,3 @@
-
-data "aws_ami" "al2023" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-*-x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name = "architecture"
-    values = ["x86_64"]
-  }
-
-  owners = ["137112412989"]
-}
-
 data "aws_kms_key" "ebs_kms_key" {
   key_id = "alias/aws/ebs"
 }
@@ -32,7 +10,7 @@ data "aws_vpc" "target_vpc" {
 
 resource "aws_instance" "star_rocks_compute_nodes" {
   count = var.compute_node_instance_count
-  ami                    = data.aws_ami.al2023.id
+  ami                    = var.ami_id
   instance_type          = var.monitoring_instance_type
   user_data = templatefile("${path.module}/templates/compute_node_startup.sh.tpl", {
     starrocks_version        = var.star_rocks_version

--- a/variables.tf
+++ b/variables.tf
@@ -81,7 +81,7 @@ variable "ssh_key_name" {
   default = "devops"
 }
 
-variable "additional_policies_arns" {
+variable "additional_policy_arns" {
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "project" {
 variable "starrocks_bucket" {
 }
 
+# Amazon Linux 2023 HVM x86_64
+variable "ami_id" {
+
+}
+
 variable "vpc_id" {
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -81,3 +81,7 @@ variable "ssh_key_name" {
   default = "devops"
 }
 
+variable "additional_policies_arns" {
+  default = []
+}
+


### PR DESCRIPTION
Allow a list of additional IAM policies to mount to the Star Rocks instances. Also don't lookup the AMI to avoid redeploying the instances and deleting data on accident.