### PR TITLE
🐛 fix: SJRA-321 fix usage of instance types when creating resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "aws_vpc" "target_vpc" {
 resource "aws_instance" "star_rocks_compute_nodes" {
   count = var.compute_node_instance_count
   ami                    = var.ami_id
-  instance_type          = var.monitoring_instance_type
+  instance_type          = var.compute_node_instance_type
   user_data = templatefile("${path.module}/templates/compute_node_startup.sh.tpl", {
     starrocks_version        = var.star_rocks_version
     starrocks_data_path = var.starrocks_data_path
@@ -52,7 +52,7 @@ resource "aws_instance" "star_rocks_compute_nodes" {
 resource "aws_instance" "star_rocks_frontend" {
   count = var.frontend_instance_count
   ami                    = var.ami_id
-  instance_type          = var.monitoring_instance_type
+  instance_type          = var.frontend_instance_type
   user_data = templatefile("${path.module}/templates/frontend_startup.sh.tpl", {
     starrocks_version        = var.star_rocks_version
     starrocks_data_path = var.starrocks_data_path


### PR DESCRIPTION
This PR fixes the usage of instance type coming from variables for compute nodes and frontend nodes.

Previously the values were set from `monitoring_instance_type` which should be reserved for monitoring tooling instances. 
