### PR TITLE
Upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ where the default for `PORT` is `9030`. After that, you can access Star Rocks us
 mysql -h 127.0.0.1 -P 9030 -u root
 ```
 
+## Upgrade Process
+Currently full blue/green is not supported. Instead, we do a modified canary process for upgrades.
+1. Change the value for `starrocks_upgrade_version` in `variables.tfvars` for your environment.
+2. Create a PR, get reviews, and merge.
+3. This will create a new set of instances with the new version (upgrade or downgrade).
+4. Backup the old Frontend's metadata manually through SSM
+5. Migrate the metadata to the new Frontend manually through SSM
+6. Verify new CNs joined the old FE correctly.
+7. Verify new FE has metadata successfully.
+8. Now set the `starrocks_upgrade_version` to blank, and the `starrocks_verison` to the new version.
+9. This will delete the upgraded instances and the old version's instances. A new set of upgraded instances will be created.
+10. Migrate the metadata on the new FE again.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/main.tf
+++ b/main.tf
@@ -163,3 +163,85 @@ resource "aws_instance" "star_rocks_prometheus" {
     Starrocks_Backup  = "false"
   }
 }
+
+resource "aws_instance" "upgrade_compute_nodes" {
+  count = var.star_rocks_upgrade_version != "" ? var.compute_node_instance_count : 0
+  ami                    = var.ami_id
+  instance_type          = var.monitoring_instance_type
+  user_data = templatefile("${path.module}/templates/compute_node_startup.sh.tpl", {
+    starrocks_version        = var.star_rocks_upgrade_version
+    starrocks_data_path = var.starrocks_data_path
+    fe_host = aws_route53_record.private_star_rocks_dns.fqdn
+    fe_query_port = 9030
+    vpc_cidr = data.aws_vpc.target_vpc.cidr_block
+    java_heap_size_mb = var.compute_node_heap_size
+  })
+  iam_instance_profile   = aws_iam_instance_profile.star_rocks_instance_profile.name
+  vpc_security_group_ids = [aws_security_group.star_rocks_sg.id]
+  subnet_id              = var.subnet_id
+  key_name               = var.ssh_key_name
+  ebs_optimized          = true
+  monitoring             = true
+  volume_tags = {
+    Name              = "${var.project}-cn-${var.environment}-volume"
+    Application       = var.project
+    Description       = "Instance for ${var.project}"
+    Starrocks_Backup  = "true"
+  }
+  root_block_device {
+    volume_type = "standard"
+    volume_size = var.cn_volume_size_gb
+    encrypted   = "true"
+  }
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+  tags = {
+    Name                 = "${var.project}-cn-${var.environment}"
+    Application          = "${var.project}-cn"
+    Description          = "Instance for ${var.project}"
+    Starrocks_Backup  = "true"
+  }
+}
+
+resource "aws_instance" "star_rocks_frontend" {
+  count = var.star_rocks_upgrade_version != "" ? var.frontend_instance_count : 0
+  ami                    = var.ami_id
+  instance_type          = var.monitoring_instance_type
+  user_data = templatefile("${path.module}/templates/frontend_startup.sh.tpl", {
+    starrocks_version        = var.star_rocks_upgrade_version
+    starrocks_data_path = var.starrocks_data_path
+    region = var.region
+    bucket = "${var.starrocks_bucket}"
+    vpc_cidr = data.aws_vpc.target_vpc.cidr_block
+    java_heap_size_mb = var.frontend_heap_size
+  })
+  iam_instance_profile   = aws_iam_instance_profile.star_rocks_instance_profile.name
+  vpc_security_group_ids = [aws_security_group.star_rocks_sg.id]
+  subnet_id              = var.subnet_id
+  key_name               = var.ssh_key_name
+  ebs_optimized          = true
+  monitoring             = true
+  volume_tags = {
+    Name              = "${var.project}-fe-${var.environment}-volume"
+    Application       = var.project
+    Description       = "Instance for ${var.project}"
+    Starrocks_Backup  = "true"
+  }
+  root_block_device {
+    volume_type = "standard"
+    volume_size = var.frontend_volume_size_gb
+    encrypted   = "true"
+  }
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+  tags = {
+    Name                 = "${var.project}-fe-${var.environment}"
+    Application          = "${var.project}-fe"
+    Description          = "Instance for ${var.project}"
+    Starrocks_Backup  = "true"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ resource "aws_instance" "upgrade_compute_nodes" {
     http_tokens   = "required"
   }
   tags = {
-    Name                 = "${var.project}-cn-${var.environment}"
+    Name                 = "${var.project}-cn-${var.environment}-upgrade"
     Application          = "${var.project}-cn"
     Description          = "Instance for ${var.project}"
     Starrocks_Backup  = "true"
@@ -239,7 +239,7 @@ resource "aws_instance" "upgrade_star_rocks_frontend" {
     http_tokens   = "required"
   }
   tags = {
-    Name                 = "${var.project}-fe-${var.environment}"
+    Name                 = "${var.project}-fe-${var.environment}-upgrade"
     Application          = "${var.project}-fe"
     Description          = "Instance for ${var.project}"
     Starrocks_Backup  = "true"

--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,7 @@ resource "aws_instance" "upgrade_compute_nodes" {
   }
 }
 
-resource "aws_instance" "star_rocks_frontend" {
+resource "aws_instance" "upgrade_star_rocks_frontend" {
   count = var.star_rocks_upgrade_version != "" ? var.frontend_instance_count : 0
   ami                    = var.ami_id
   instance_type          = var.monitoring_instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,10 @@ variable "star_rocks_version" {
   default = "3.3.11"
 }
 
+variable "star_rocks_upgrade_version" {
+  default = ""
+}
+
 variable "starrocks_data_path" {
   default = "/opt/starrocks/"
 }


### PR DESCRIPTION
Allow new EC2 instances when changing versions. This does require a redeploy, but allows you to test the new version for any compatibility issues.

When the upgrade version is set, the module will create a new set of instances with the new version. The CNs will join the existing FE to verify they can join the old version of FE. The new FE will start its own cluster. You will need to manually migrate the metadata snapshot to the new FE, ensuring that the MySQL server gets all the old metadata. 

Then you will change the `star_rocks_upgrade_version` to an empty string again, and update `star_rocks_version` with the new version. This will recreate the cluster, and you will need to manually migrate the metadata snapshot again. 