### PR TITLE
:sparkles: output role arn

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "fe_dns_name" {
 output "grafana_address" {
   value = aws_instance.star_rocks_grafana.private_ip
 }
+
+output "star_rocks_role_arn" {
+  value = aws_iam_role.star_rocks_role.arn
+}


### PR DESCRIPTION
This pull request adds a new Terraform output to expose the ARN of the `star_rocks_role` IAM role. This allows other modules or users to easily reference this role's ARN after deployment.
