### PR TITLE
java 17

### DIFF
--- a/templates/frontend_startup.sh.tpl
+++ b/templates/frontend_startup.sh.tpl
@@ -1,5 +1,5 @@
 #!/bin/bash
-JAVA_PACKAGE=java-11-amazon-corretto
+JAVA_PACKAGE=java-17-amazon-corretto
 sudo dnf install -y $JAVA_PACKAGE-devel mariadb105 || (sleep 120 ; sudo dnf install -y $JAVA_PACKAGE-devel mariadb105)
 
 sudo su


### PR DESCRIPTION
We need to match the Celerdata cluster's version to migrate to it. It is on 3.5.14. To upgrade the Starrocks cluster to 3.5.x, we need Java 17. 