### PR TITLE
make optional route 53 and prometheus + fix issues with s3 object creation

### DIFF
--- a/dashboard_upload.tf
+++ b/dashboard_upload.tf
@@ -8,5 +8,11 @@ resource "aws_s3_object" "overview_dashboard" {
   source                 = "${path.module}/grafana_dashboards/overview.json"
   server_side_encryption = "aws:kms"
   acl                    = "private"
-  etag                   = filemd5("${path.module}/grafana_dashboards/overview.json")
+  source_hash            = filemd5("${path.module}/grafana_dashboards/overview.json")
+
+  override_provider {
+    default_tags {
+      tags = {}
+    }
+  }
 }

--- a/dashboard_upload.tf
+++ b/dashboard_upload.tf
@@ -1,9 +1,11 @@
 data "aws_s3_bucket" "star_rocks_bucket" {
+  count  = var.include_prometheus_monitoring ? 1 : 0
   bucket = var.starrocks_bucket
 }
 
 resource "aws_s3_object" "overview_dashboard" {
-  bucket                 = data.aws_s3_bucket.star_rocks_bucket.id
+  count                  = var.include_prometheus_monitoring ? 1 : 0
+  bucket                 = data.aws_s3_bucket.star_rocks_bucket[0].id
   key                    = "dashboards/overview.json"
   source                 = "${path.module}/grafana_dashboards/overview.json"
   server_side_encryption = "aws:kms"

--- a/grafana.tf
+++ b/grafana.tf
@@ -1,8 +1,9 @@
 resource "aws_instance" "star_rocks_grafana" {
+  count         = var.include_prometheus_monitoring ? 1 : 0
   ami           = var.ami_id
   instance_type = var.monitoring_instance_type
   user_data = templatefile("${path.module}/templates/grafana_startup.sh.tpl", {
-    prometheus_ip = aws_instance.star_rocks_prometheus.private_ip
+    prometheus_ip = aws_instance.star_rocks_prometheus[0].private_ip
     bucket        = "${var.starrocks_bucket}"
     pw_secret     = "${var.project}-${var.environment}-grafana-admin-pw"
   })
@@ -37,6 +38,7 @@ resource "aws_instance" "star_rocks_grafana" {
 
 
 resource "aws_instance" "star_rocks_prometheus" {
+  count         = var.include_prometheus_monitoring ? 1 : 0
   ami           = var.ami_id
   instance_type = var.monitoring_instance_type
   user_data = templatefile("${path.module}/templates/prometheus_startup.sh.tpl", {

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_instance" "star_rocks_compute_nodes" {
   user_data = templatefile("${path.module}/templates/compute_node_startup.sh.tpl", {
     starrocks_version   = count.index == (local.canary_compute_node_count - 1) ? var.star_rocks_version : local.canary_version
     starrocks_data_path = var.starrocks_data_path
-    fe_host             = aws_route53_record.private_star_rocks_dns.fqdn
+    fe_host             = "${var.project}-${var.environment}.${var.domain_name}"
     fe_query_port       = 9030
     vpc_cidr            = data.aws_vpc.target_vpc.cidr_block
     java_heap_size_mb   = var.compute_node_heap_size

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "fe_dns_name" {
-  value = aws_route53_record.private_star_rocks_dns.fqdn
+  value = "${var.project}-${var.environment}.${var.domain_name}"
 }
 
 output "grafana_address" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "fe_dns_name" {
 }
 
 output "grafana_address" {
-  value = aws_instance.star_rocks_grafana.private_ip
+  value = one(aws_instance.star_rocks_grafana[*].private_ip)
 }
 
 output "star_rocks_role_arn" {

--- a/route53.tf
+++ b/route53.tf
@@ -1,10 +1,12 @@
 data "aws_route53_zone" "private_dns_zone" {
+  count        = var.create_dns_record ? 1 : 0
   name         = "${var.domain_name}."
   private_zone = var.private_dns_zone
 }
 
 resource "aws_route53_record" "private_star_rocks_dns" {
-  zone_id = data.aws_route53_zone.private_dns_zone.zone_id
+  count   = var.create_dns_record ? 1 : 0
+  zone_id = data.aws_route53_zone.private_dns_zone[0].zone_id
   name    = "${var.project}-${var.environment}"
   type    = "A"
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,10 @@ variable "subnet_id" {
 variable "domain_name" {
 }
 
+variable "create_dns_record" {
+  default = true
+}
+
 variable "private_dns_zone" {
   default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,10 @@ variable "monitoring_instance_type" {
   default = "m6i.large"
 }
 
+variable "include_prometheus_monitoring" {
+  default = true
+}
+
 variable "star_rocks_version" {
   default = "3.4.4"
 }


### PR DESCRIPTION
3 improvements to deploy in a restricted AWS environment:
1. Optional Route 53 record creation
    1. New `create_route53_record` variable (default to `true`) to skip Route 53 record creation when the account lacks permissions and the record must be managed separately
2. Issues with S3 object creation
    1. Constant drift: every apply was showing a change because the file was encrypted at the destination
    2. Tag limit failure: apply was failing when more than 10 default tags
3. Optional Prometheus monitoring creation
    1. New `include_prometheus_monitoring` variable (default to `true`) to skip Prometheus instances to be created along with the Grafana dashboad file in S3